### PR TITLE
Update quick_start.md

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -18,6 +18,10 @@ or
 
 `cookiecutter gh:OBASKTools/obask-template`
 
+or
+
+`python3 -m cookiecutter gh:OBASKTools/obask-template`
+
 Then provide your `project_name` when asked.
 
 3. Commit your project to GitHub. Be bold, if you are not satisfied with the result, you can delete the repository and create it again as many times as you want.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -28,9 +28,9 @@ Then provide your `project_name` when asked.
 
     - Navigate to your newly created project folder and initialize the git repository.
     ```
-    git init -b main
-    git add .
-    git commit -m "First commit"
+    git init -b main 
+    git add . 
+    git commit -m "First commit" 
     ```
 
     - [Create a new repository](https://github.com/new). Repo name should be same with the `project_name` you provided to the template.
@@ -41,9 +41,9 @@ Then provide your `project_name` when asked.
 
     - See the section under "…or push an existing repository from the command line". Follow the instructions there. E.g. (make sure the location of your remote is exactly correct!).
     ```
-    git remote add origin https://github.com/MyRepo/my_project_name.git
-    git branch -M main
-    git push -u origin main
+    git remote add origin https://github.com/MyRepo/my_project_name.git 
+    git branch -M main 
+    git push -u origin main 
     ```
 
 4. Customise your configs:


### PR DESCRIPTION
`cookiecutter gh:OBASKTools/obask-template` command failed with `zsh: command not found: cookiecutter` error in my new macOS environment. 

Updated the documentation to provide and alternative way to run the cookie cutter.